### PR TITLE
Add jdkinternals parameter support (fixes #24)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jdeps/AbstractJDepsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeps/AbstractJDepsMojo.java
@@ -184,6 +184,14 @@ public abstract class AbstractJDepsMojo extends AbstractMojo {
     @Parameter(property = "jdeps.module")
     private String module;
 
+    /**
+     * Show only internal API usage.
+     *
+     * @since 3.2.0
+     */
+    @Parameter(defaultValue = "false", property = "jdeps.jdkinternals")
+    private boolean jdkinternals;
+
     private final ToolchainManager toolchainManager;
 
     protected AbstractJDepsMojo(ToolchainManager toolchainManager) {
@@ -312,6 +320,10 @@ public abstract class AbstractJDepsMojo extends AbstractMojo {
 
         if (recursive) {
             cmd.createArg().setValue("-R");
+        }
+
+        if (jdkinternals) {
+            cmd.createArg().setValue("-jdkinternals");
         }
     }
 

--- a/src/test/java/org/apache/maven/plugins/jdeps/AbstractJDepsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jdeps/AbstractJDepsMojoTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jdeps;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractJDepsMojoTest {
+
+    private static class TestJDepsMojo extends AbstractJDepsMojo {
+        TestJDepsMojo(ToolchainManager toolchainManager) {
+            super(toolchainManager);
+        }
+
+        @Override
+        protected String getClassesDirectory() {
+            return "/path/to/classes";
+        }
+
+        @Override
+        protected Collection<Path> getClassPath() throws DependencyResolutionRequiredException {
+            return new HashSet<>();
+        }
+    }
+
+    @Test
+    void testJDKInternalsOptionIsAdded() throws Exception {
+        TestJDepsMojo mojo = new TestJDepsMojo(null);
+
+        // Set jdkinternals to true
+        Field jdkInternalsField = AbstractJDepsMojo.class.getDeclaredField("jdkinternals");
+        jdkInternalsField.setAccessible(true);
+        jdkInternalsField.setBoolean(mojo, true);
+
+        Commandline cmd = new Commandline();
+        Set<Path> dependenciesToAnalyze = new HashSet<>();
+        dependenciesToAnalyze.add(Paths.get("/path/to/classes"));
+
+        mojo.addJDepsOptions(cmd, dependenciesToAnalyze);
+
+        String cmdLine = cmd.toString();
+        assertTrue(cmdLine.contains("-jdkinternals"), "Command line should contain -jdkinternals flag");
+    }
+
+    @Test
+    void testJDKInternalsOptionNotAddedWhenFalse() throws Exception {
+        TestJDepsMojo mojo = new TestJDepsMojo(null);
+
+        // Set jdkinternals to false (default)
+        Field jdkInternalsField = AbstractJDepsMojo.class.getDeclaredField("jdkinternals");
+        jdkInternalsField.setAccessible(true);
+        jdkInternalsField.setBoolean(mojo, false);
+
+        Commandline cmd = new Commandline();
+        Set<Path> dependenciesToAnalyze = new HashSet<>();
+        dependenciesToAnalyze.add(Paths.get("/path/to/classes"));
+
+        mojo.addJDepsOptions(cmd, dependenciesToAnalyze);
+
+        String cmdLine = cmd.toString();
+        assertFalse(
+                cmdLine.contains("-jdkinternals"), "Command line should not contain -jdkinternals flag when disabled");
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses issue #24 by adding support for the `-jdkinternals` flag to the maven-jdeps-plugin.

## Changes

1. **New Feature**: Added 'jdkinternals' parameter to AbstractJDepsMojo that enables the `-jdkinternals` flag when running jdeps
   - Default: false (disabled)
   - Can be enabled via POM configuration: `<jdkinternals>true</jdkinternals>`
   - Also available as command-line property: `-Djdeps.jdkinternals=true`
2. **Unit Tests**: Added comprehensive unit tests for the new jdkinternals parameter

## Issue Resolution

Fixes #24 - The plugin now supports the jdeps `-jdkinternals` option which restricts analysis to show only internal API usage.