### PR TITLE
Use the semeru distribution instead of adopt-openj9

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      jdk-distribution-matrix: '[ "zulu", "microsoft", "liberica", "adopt-openj9" ]'
+      jdk-distribution-matrix: '[ "zulu", "microsoft", "liberica", "semeru" ]'
       matrix-exclude: '[{ "jdk": "8", "distribution": "microsoft"},{ "jdk": "8", "os": "macos-latest"}]'
       maven4-enabled: true


### PR DESCRIPTION
`actions/setup-java` no longer lists `adopt-openj9` — IBM's OpenJ9 builds are published as [`semeru`](https://github.com/actions/setup-java#supported-distributions). Every cell using the old alias fails before Maven starts, with `No supported distribution was found for input adopt-openj9`; apache/maven-javadoc-plugin is currently red for exactly this (#1373 renames it there, and apache/maven-jlink-plugin already uses `semeru`).

Straight rename. The existing exclusions still cover the one gap: Semeru has no macOS aarch64 build for 8, and `{ "jdk": "8", "os": "macos-latest"}` already excludes that for every distribution.

*This change was created with AI assistance.*
