### PR TITLE
Migrate the site descriptor to the v2 model

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -18,9 +18,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+<site xmlns="http://maven.apache.org/SITE/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <links>
       <item name="Javadoc Tool" href="http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/"/>
@@ -40,4 +40,4 @@ under the License.
     </menu>
     -->
   </body>
-</project>
+</site>


### PR DESCRIPTION
Converts `src/site/site.xml` from the v1 DECORATION model to the v2 SITE/2.1.0 model: only the root element and namespace/schemaLocation change (CRLF line endings preserved). Doxia Sitetools warns on every build that "Site model ... is still using the old pre-version 2.0.0 model. You MUST migrate to the new model as soon as possible otherwise your build will break in the future!"

Verified: the converted file validates against `site-2.1.0.xsd`, and `mvn -B site -DskipTests` completes with BUILD SUCCESS with the old-model warning no longer present in the log.

*This change was created with AI assistance.*